### PR TITLE
Fix reliance on having message actions expanded

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -73,7 +73,7 @@ export function handleCollapseDisabledClick() {
         // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
         if (chat[mes_id].is_system) {
             let message = $('.mes[mesid="'+mes_id+'"]');
-            collapseMessage(mes_id);
+            collapseMessage(message);
             count++;
         }
     }

--- a/actions.js
+++ b/actions.js
@@ -25,9 +25,7 @@ export function removeCollapseArrowsFromMessages() {
 }
 
 // Function to collapse message
-function collapseMessage(mes_id) {
-    const message = $('.mes[mesid="'+mes_id+'"]');
-
+function collapseMessage(message) {
     const messageText = message.find('.mes_text');
     const arrowSpan = message.find('.' + arrowClass);
     const icon = arrowSpan.find('i');
@@ -40,9 +38,7 @@ function collapseMessage(mes_id) {
 }
 
 // Function to expand message
-function expandMessage(mes_id) {
-    const message = $('.mes[mesid="'+mes_id+'"]');
-
+function expandMessage(message) {
     const messageText = message.find('.mes_text');
     const arrowSpan = message.find('.' + arrowClass);
     const icon = arrowSpan.find('i');
@@ -76,6 +72,7 @@ export function handleCollapseDisabledClick() {
     for (var mes_id = 0; mes_id < chat.length; mes_id++) {
         // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
         if (chat[mes_id].is_system) {
+            let message = $('.mes[mesid="'+mes_id+'"]');
             collapseMessage(mes_id);
             count++;
         }
@@ -94,7 +91,8 @@ export function handleExpandDisabledClick() {
     for (var mes_id = 0; mes_id < chat.length; mes_id++) {
         // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
         if (chat[mes_id].is_system) {
-            expandMessage(mes_id);
+            let message = $('.mes[mesid="'+mes_id+'"]');
+            expandMessage(message);
             count++;
         }
     }
@@ -111,18 +109,8 @@ export function handleExpandAllClick() {
     let count = 0;
     $('.mes').each(function() {
         const message = $(this);
-        if (message.find('.mes_text').is(':hidden') || message.hasClass(collapsedClass)) {
-            const messageText = message.find('.mes_text');
-            const arrowSpan = message.find('.' + arrowClass);
-            const icon = arrowSpan.find('i');
-
-            messageText.show();
-            message.removeClass(collapsedClass);
-            if (arrowSpan.length && icon.length) {
-                icon.removeClass('fa-chevron-right').addClass('fa-chevron-down');
-            }
-            count++;
-        }
+        expandMessage(message);
+        count++;
     });
     if (count > 0) {
         toastr.success(count + (count === 1 ? " message expanded." : " messages expanded."));
@@ -136,18 +124,8 @@ export function handleCollapseAllClick() {
     let count = 0;
     $('.mes').each(function() {
         const message = $(this);
-        if (message.find('.mes_text').is(':visible') || !message.hasClass(collapsedClass)) {
-            const messageText = message.find('.mes_text');
-            const arrowSpan = message.find('.' + arrowClass);
-            const icon = arrowSpan.find('i');
-
-            messageText.hide();
-            message.addClass(collapsedClass);
-            if (arrowSpan.length && icon.length) {
-                icon.removeClass('fa-chevron-down').addClass('fa-chevron-right');
-            }
-            count++;
-        }
+        collapseMessage(message);
+        count++;
     });
     if (count > 0) {
         toastr.success(count + (count === 1 ? " message collapsed." : " messages collapsed."));

--- a/actions.js
+++ b/actions.js
@@ -1,7 +1,10 @@
 // actions.js - Handles message manipulation and UI actions for Message_Collapser
 
+import { getContext } from "../../../extensions.js";
+
 export const arrowClass = 'message-collapser-arrow';
 export const collapsedClass = 'message-collapser-message-collapsed';
+let chat = getContext().chat
 
 // Function to add collapse/expand arrows to messages
 export function addCollapseArrowsToMessages() {
@@ -19,6 +22,36 @@ export function addCollapseArrowsToMessages() {
 export function removeCollapseArrowsFromMessages() {
     console.log("Message Collapser: Removing collapse arrows.");
     $('.' + arrowClass).remove();
+}
+
+// Function to collapse message
+function collapseMessage(mes_id) {
+    const message = $('.mes[mesid="'+mes_id+'"]');
+
+    const messageText = message.find('.mes_text');
+    const arrowSpan = message.find('.' + arrowClass);
+    const icon = arrowSpan.find('i');
+
+    messageText.hide();
+    message.addClass(collapsedClass);
+    if (arrowSpan.length && icon.length) {
+        icon.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    }
+}
+
+// Function to expand message
+function expandMessage(mes_id) {
+    const message = $('.mes[mesid="'+mes_id+'"]');
+
+    const messageText = message.find('.mes_text');
+    const arrowSpan = message.find('.' + arrowClass);
+    const icon = arrowSpan.find('i');
+
+    messageText.show();
+    message.removeClass(collapsedClass);
+    if (arrowSpan.length && icon.length) {
+        icon.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    }
 }
 
 // Handler for clicking an arrow
@@ -39,70 +72,37 @@ export function handleArrowClick(event) {
 }
 
 export function handleCollapseDisabledClick() {
-    const disabledSelectorString = "$('.mes_unhide.fa-eye-slash:visible').closest('.mes')";
-    const $disabledMessages = $('.mes_unhide.fa-eye-slash:visible').closest('.mes');
-    const $allMessages = $('.mes');
-
-
-    if ($disabledMessages.length === 0) {
-        toastr.info("No 'hidden' messages (with visible .mes_unhide.fa-eye-slash) found to collapse.");
-        return;
-    }
-
     let count = 0;
-    $disabledMessages.each(function(index) {
-        const message = $(this);
-
-        const messageText = message.find('.mes_text');
-        const arrowSpan = message.find('.' + arrowClass);
-        const icon = arrowSpan.find('i');
-
-        messageText.hide();
-        message.addClass(collapsedClass);
-        if (arrowSpan.length && icon.length) {
-            icon.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    for (var mes_id = 0; mes_id < chat.length; mes_id++) {
+        // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
+        if (chat[mes_id].is_system) {
+            collapseMessage(mes_id);
+            count++;
         }
-        count++;
-    });
+    }
 
     if (count > 0) {
         toastr.success(count + (count === 1 ? " 'hidden' message collapsed." : " 'hidden' messages collapsed."));
     } else {
-        toastr.info("No 'hidden' messages found to collapse (post-loop check).");
+        toastr.info("No 'hidden' messages found to collapse.");
     }
+
 }
 
 export function handleExpandDisabledClick() {
-    const disabledSelectorString = "$('.mes_unhide.fa-eye-slash:visible').closest('.mes')";
-    const $disabledMessages = $('.mes_unhide.fa-eye-slash:visible').closest('.mes');
-    const $allMessages = $('.mes');
-
-
-    if ($disabledMessages.length === 0) {
-        toastr.info("No 'hidden' messages (with visible .mes_unhide.fa-eye-slash) found to expand.");
-        return;
-    }
-
     let count = 0;
-    $disabledMessages.each(function(index) {
-        const message = $(this);
-
-        const messageText = message.find('.mes_text');
-        const arrowSpan = message.find('.' + arrowClass);
-        const icon = arrowSpan.find('i');
-
-        messageText.show();
-        message.removeClass(collapsedClass);
-        if (arrowSpan.length && icon.length) {
-            icon.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    for (var mes_id = 0; mes_id < chat.length; mes_id++) {
+        // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
+        if (chat[mes_id].is_system) {
+            expandMessage(mes_id);
+            count++;
         }
-        count++;
-    });
+    }
 
     if (count > 0) {
         toastr.success(count + (count === 1 ? " 'hidden' message expanded." : " 'hidden' messages expanded."));
     } else {
-        toastr.info("No 'hidden' messages found to expand (post-loop check).");
+        toastr.info("No 'hidden' messages found to expand.");
     }
 }
 


### PR DESCRIPTION
Changes the check from DOM element visibility to the actual message property flagging it as hidden. I also pulled out the collapse/expand logic into reusable functions instead of embedded anonymous functions so the logic can be reused instead of repeated.